### PR TITLE
Adding compatiblity with Gnome 3.18

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,6 +2,6 @@
     "uuid": "ProxySwitcher@flannaghan.com", 
     "name": "Proxy Switcher", 
     "description": "Switches between the system proxy settings profiles defined in Network Settings.",
-    "shell-version": ["3.10", "3.12", "3.14", "3.16"],
+    "shell-version": ["3.10", "3.12", "3.14", "3.16", "3.18"],
     "url": "https://github.com/tomflannaghan/proxy-switcher"
 }


### PR DESCRIPTION
The plugin works with Gnome 3.18, so you can update version number.