### PR TITLE
Make compatible with Gnome 40

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,6 +2,6 @@
     "uuid": "ProxySwitcher@flannaghan.com",
     "name": "Proxy Switcher",
     "description": "Switches between the system proxy settings profiles defined in Network Settings.",
-    "shell-version": ["3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "3.21.91", "3.22", "3.22.2"],
+    "shell-version": ["3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "3.21.91", "3.22", "3.22.2", "40"],
     "url": "https://github.com/tomflannaghan/proxy-switcher"
 }


### PR DESCRIPTION
The extension has been tested on Gnome 40 (using Fedora 34) and works fine without any changes to the code.