### PR TITLE
Make the extentions available in Gnome 41

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,6 +2,6 @@
     "uuid": "ProxySwitcher@flannaghan.com",
     "name": "Proxy Switcher",
     "description": "Switches between the system proxy settings profiles defined in Network Settings.",
-    "shell-version": ["3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "3.21.91", "3.22", "3.22.2", "40"],
+    "shell-version": ["3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "3.21.91", "3.22", "3.22.2", "40", "41"],
     "url": "https://github.com/tomflannaghan/proxy-switcher"
 }


### PR DESCRIPTION
Only fix metadata.json, all seems to work for me without further fixes.

On Debian Testing we received Gnome41.

```
$ gnome-shell --version
GNOME Shell 41.0
```

While gnome-shell reports '41.0', I tested '41' in metadata.json and that works. So it seems better to keep it like that instead of the need to update for minor version too?

Note: THANKS for the plugin, pretty essential for me, working in different (proxied) environments...