### PR TITLE
Add 42 to versions

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,6 +2,6 @@
     "uuid": "ProxySwitcher@flannaghan.com",
     "name": "Proxy Switcher",
     "description": "Switches between the system proxy settings profiles defined in Network Settings.",
-    "shell-version": ["40", "41"],
+    "shell-version": ["40", "41", "42"],
     "url": "https://github.com/tomflannaghan/proxy-switcher"
 }


### PR DESCRIPTION
Just testing here on Debian testing: first steps in gnome 42, but adding 42 to metadata seems to make the extension just work...

Others feel free to test