### PR TITLE
Switch to QuickMenuToggle for GNOME 43

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,6 +2,6 @@
     "uuid": "ProxySwitcher@flannaghan.com",
     "name": "Proxy Switcher",
     "description": "Switches between the system proxy settings profiles defined in Network Settings.",
-    "shell-version": ["3.36", "3.38", "40", "41", "42"],
+    "shell-version": ["43"],
     "url": "https://github.com/tomflannaghan/proxy-switcher"
 }


### PR DESCRIPTION
This switches the extension to the new fancy QuickSettings.

fixes #27