### PR TITLE
Mark as Gnome 46 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ I recommend using the gnome extensions site but this is not always up to date. T
 
 ## Older Gnome versions
 
-Current master branch only supports version 45. There have been breaking changes to the Gnome Shell API. The best way to download the appropriate version for your Gnome is via the [extensions website](https://extensions.gnome.org/extension/771/proxy-switcher/), where
+Current master branch only supports versions >= 45. There have been breaking changes to the Gnome Shell API. The best way to download the appropriate version for your Gnome is via the [extensions website](https://extensions.gnome.org/extension/771/proxy-switcher/), where
 you can select the shell version you would like.
 
 There are branches for some older versions of Gnome, e.g. `gnome44` branch for Gnome 44.

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "ProxySwitcher@flannaghan.com",
     "name": "Proxy Switcher",
     "description": "Switches between the system proxy settings profiles defined in Network Settings.",
-    "shell-version": ["45"],
+    "shell-version": ["45", "46"],
     "url": "https://github.com/tomflannaghan/proxy-switcher",
     "gettext-domain": "ProxySwitcher@flannaghan.com"
 }


### PR DESCRIPTION
Tested on Gnome 46. Works as expected and no warnings in journal.